### PR TITLE
change rpm macros to sign with sha256 algo. Fixes #14

### DIFF
--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -3,6 +3,9 @@ MAINTAINER Jason Swank <jswank@sonatype.com>
 
 RUN yum -y install expect
 
+# force sha256 signature of rpm, instead of old default of sha1 used by CentOS7
+RUN echo '%_gpg_digest_algo sha256' >> /usr/lib/rpm/macros
+
 COPY ./ /data
 RUN chown -R nobody /data/*
 VOLUME /data


### PR DESCRIPTION
See this comment on original issue: https://github.com/sonatype-nexus-community/nexus-repository-installer/issues/25#issuecomment-1339917839
Gonna merge this puppy because I think it works.